### PR TITLE
Add ssm-parameter-store-settings module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@
 Terraform module which creates secret related resources on AWS.
 
 
+## Target AWS Services
+
+Terraform Modules from [this package](https://github.com/tedilabs/terraform-aws-secret) were written to manage the following AWS Services with Terraform.
+
+- **KMS (Key Management Service)**
+  - CMK (Customer Master Key)
+  - Key Alias
+  - Grant (Comming soon!)
+- **Secrets Manager**
+  - Secret
+  - Secret Versions
+  - Resource Policy for Secret
+  - Configuration for Secret Rotation
+- **SSM Parameter Store**
+  - Parameters (Comming soon!)
+  - Service Settings
+
+
 ## Self Promotion
 
 Like this project? Follow the repository on [GitHub](https://github.com/tedilabs/terraform-aws-secret). And if you're feeling especially charitable, follow **[posquit0](https://github.com/posquit0)** on GitHub.

--- a/modules/ssm-parameter-store-settings/README.md
+++ b/modules/ssm-parameter-store-settings/README.md
@@ -1,0 +1,46 @@
+# ssm-parameter-store-settings
+
+This module creates following resources.
+
+- `aws_ssm_service_setting`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssm_service_setting.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_service_setting) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_default_parameter_tier"></a> [default\_parameter\_tier](#input\_default\_parameter\_tier) | (Optional) The parameter tier to use by default when a request to create or update a parameter does not specify a tier. The intended type of the secret. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`. Defaults to `STANDARD`. | `string` | `"STANDARD"` | no |
+| <a name="input_high_throughput_enabled"></a> [high\_throughput\_enabled](#input\_high\_throughput\_enabled) | (Optional) Whether to increase Parameter Store throughput. Defaults to `false`. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_default_parameter_tier"></a> [default\_parameter\_tier](#output\_default\_parameter\_tier) | The parameter tier to use by default when a request to create or update a parameter does not specify a tier. |
+| <a name="output_high_throughput_enabled"></a> [high\_throughput\_enabled](#output\_high\_throughput\_enabled) | Whether to increase Parameter Store throughput. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssm-parameter-store-settings/main.tf
+++ b/modules/ssm-parameter-store-settings/main.tf
@@ -1,0 +1,40 @@
+locals {
+  metadata = {
+    package = "terraform-aws-secret"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = local.region
+  }
+}
+
+data "aws_caller_identity" "this" {}
+data "aws_region" "this" {}
+
+locals {
+  account_id = data.aws_caller_identity.this.account_id
+  region     = data.aws_region.this.name
+
+  parameter_tiers = {
+    "STANDARD"            = "Standard"
+    "ADVANCED"            = "Advanced"
+    "INTELLIGENT_TIERING" = "Intelligent-Tiering"
+  }
+
+  setting_id_prefix = "arn:aws:ssm:${local.region}:${local.account_id}:servicesetting/ssm/parameter-store"
+  settings = {
+    "default-parameter-tier"  = local.parameter_tiers[var.default_parameter_tier]
+    "high-throughput-enabled" = var.high_throughput_enabled ? "true" : "false"
+  }
+}
+
+
+###################################################
+# Settings for Parameter Store on SSM (Systems Manager)
+###################################################
+
+resource "aws_ssm_service_setting" "this" {
+  for_each = local.settings
+
+  setting_id    = "${local.setting_id_prefix}/${each.key}"
+  setting_value = each.value
+}

--- a/modules/ssm-parameter-store-settings/outputs.tf
+++ b/modules/ssm-parameter-store-settings/outputs.tf
@@ -1,0 +1,9 @@
+output "default_parameter_tier" {
+  description = "The parameter tier to use by default when a request to create or update a parameter does not specify a tier."
+  value       = var.default_parameter_tier
+}
+
+output "high_throughput_enabled" {
+  description = "Whether to increase Parameter Store throughput."
+  value       = var.high_throughput_enabled
+}

--- a/modules/ssm-parameter-store-settings/variables.tf
+++ b/modules/ssm-parameter-store-settings/variables.tf
@@ -1,0 +1,18 @@
+variable "default_parameter_tier" {
+  description = "(Optional) The parameter tier to use by default when a request to create or update a parameter does not specify a tier. The intended type of the secret. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`. Defaults to `STANDARD`."
+  type        = string
+  default     = "STANDARD"
+  nullable    = false
+
+  validation {
+    condition     = contains(["STANDARD", "ADVANCED", "INTELLIGENT_TIERING"], var.default_parameter_tier)
+    error_message = "Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`."
+  }
+}
+
+variable "high_throughput_enabled" {
+  description = "(Optional) Whether to increase Parameter Store throughput. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}

--- a/modules/ssm-parameter-store-settings/versions.tf
+++ b/modules/ssm-parameter-store-settings/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `ssm-parameter-store-settings` module to support service settings of SSM Parameter Store.