### PR TITLE
Add ssm-parameter-store-parameter-set module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -5,5 +5,7 @@
 - modules/secrets-manager-secret/**/*
 ":floppy_disk: ssm-parameter-store-parameter":
 - modules/ssm-parameter-store-parameter/**/*
+":floppy_disk: ssm-parameter-store-parameter-set":
+- modules/ssm-parameter-store-parameter-set/**/*
 ":floppy_disk: ssm-parameter-store-settings":
 - modules/ssm-parameter-store-settings/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -50,5 +50,8 @@
   description: "This issue or pull request is related to ssm-parameter-store-parameter module."
   name: ":floppy_disk: ssm-parameter-store-parameter"
 - color: "fbca04"
+  description: "This issue or pull request is related to ssm-parameter-store-parameter-set module."
+  name: ":floppy_disk: ssm-parameter-store-parameter-set"
+- color: "fbca04"
   description: "This issue or pull request is related to ssm-parameter-store-settings module."
   name: ":floppy_disk: ssm-parameter-store-settings"

--- a/examples/ssm-parameter-store-parameter-set-string-ami/main.tf
+++ b/examples/ssm-parameter-store-parameter-set-string-ami/main.tf
@@ -1,0 +1,84 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_ami" "ubuntu_bionic" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ami" "ubuntu_focal" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ami" "ubuntu_jammy" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+
+###################################################
+# Parameter on SSM Parameter Store
+###################################################
+
+module "ami" {
+  source = "../../modules/ssm-parameter-store-parameter-set"
+  # source  = "tedilabs/secret/aws//modules/ssm-parameter-store-parameter-set"
+  # version = "~> 0.3.0"
+
+  path = "/ami/ubuntu"
+  parameters = [
+    {
+      name  = "/18.04"
+      value = data.aws_ami.ubuntu_bionic.image_id
+    },
+    {
+      name  = "/20.04"
+      value = data.aws_ami.ubuntu_focal.image_id
+    },
+    {
+      name  = "/22.04"
+      value = data.aws_ami.ubuntu_jammy.image_id
+    },
+  ]
+
+  ## Default values
+  tier      = "STANDARD"
+  type      = "STRING"
+  data_type = "aws:ec2:image"
+
+  tags = {
+    "project" = "terraform-aws-secret-examples"
+  }
+}

--- a/examples/ssm-parameter-store-parameter-set-string-ami/outputs.tf
+++ b/examples/ssm-parameter-store-parameter-set-string-ami/outputs.tf
@@ -1,0 +1,3 @@
+output "ami" {
+  value = module.ami
+}

--- a/examples/ssm-parameter-store-parameter-set-string-ami/versions.tf
+++ b/examples/ssm-parameter-store-parameter-set-string-ami/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/ssm-parameter-store-parameter-set/README.md
+++ b/modules/ssm-parameter-store-parameter-set/README.md
@@ -1,0 +1,55 @@
+# ssm-parameter-store-parameter-set
+
+This module creates following resources.
+
+- `aws_ssm_parameter`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_ssm_parameter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | (Required) A list of parameters to manage in the parameter set. Each value of `parameters` block as defined below.<br>    (Required) `name` - The name of the parameter. This is concatenated with the `path` of the parameter set for the id. The name should begin with slash (/) and end without trailing slash.<br>    (Optional) `description` - The description of the parameter.<br>    (Optional) `tier` - The parameter tier to assign to the parameter. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`.<br>    (Optional) `type` - The intended type of the parameter. Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`.<br>    (Optional) `data_type` - The data type of the parameter. Only required when `type` is `STRING`. Valid values are `text`, `aws:ec2:image` for AMI format.<br>    (Optional) `allowed_pattern` - A regular expression used to validate the parameter value.<br>    (Required) `value` - The value of the parameter. | `list(map(string))` | n/a | yes |
+| <a name="input_path"></a> [path](#input\_path) | (Required) A path used for the prefix of each parameter name created by this parameter set. The path should begin with slash (/) and end without trailing slash. | `string` | n/a | yes |
+| <a name="input_allowed_pattern"></a> [allowed\_pattern](#input\_allowed\_pattern) | (Optional) The default regular expression used to validate each parameter value in the parameter set. This is only used when a specific pattern for the parameter is not provided. For example, for `STRING` types with values restricted to numbers, you can specify `^d+$`. | `string` | `""` | no |
+| <a name="input_data_type"></a> [data\_type](#input\_data\_type) | (Optional) The default data type of parameters in the parameter set. Only required when `type` is `STRING`. This is only used when a specific data type of the parameter is not provided. Valid values are `text`, `aws:ec2:image` for AMI format. Defaults to `text`. | `string` | `"text"` | no |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) The default description of parameters in the parameter set. This is only used when a specific description of the parameter is not provided. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | (Optional) The default parameter tier to assign to parameters in the parameter set. This is only used when a specific tier of the parameter is not provided. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`. Defaults to `INTELLIGENT_TIERING`. | `string` | `"INTELLIGENT_TIERING"` | no |
+| <a name="input_type"></a> [type](#input\_type) | (Optional) The default type of parameters in the parameter set. This is only used when a specific type of the parameter is not provided. Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`. Defaults to `STRING`. | `string` | `"STRING"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_parameters"></a> [parameters](#output\_parameters) | The list of parameters in the parameter set. |
+| <a name="output_path"></a> [path](#output\_path) | The path used for the prefix of each parameter names managed by this parameter set. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssm-parameter-store-parameter-set/main.tf
+++ b/modules/ssm-parameter-store-parameter-set/main.tf
@@ -1,0 +1,61 @@
+locals {
+  metadata = {
+    package = "terraform-aws-secret"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.path
+  }
+  module_tags = var.module_tags_enabled ? {
+    "module.terraform.io/package"   = local.metadata.package
+    "module.terraform.io/version"   = local.metadata.version
+    "module.terraform.io/name"      = local.metadata.module
+    "module.terraform.io/full-name" = "${local.metadata.package}/${local.metadata.module}"
+    "module.terraform.io/instance"  = local.metadata.name
+  } : {}
+}
+
+locals {
+  types = {
+    "STRING"        = "String"
+    "STRING_LIST"   = "StringList"
+    "SECURE_STRING" = "SecureString"
+  }
+  tiers = {
+    "STANDARD"            = "Standard"
+    "ADVANCED"            = "Advanced"
+    "INTELLIGENT_TIERING" = "Intelligent-Tiering"
+  }
+}
+
+
+###################################################
+# Parameter on Systems Manager Parameter Store
+###################################################
+
+resource "aws_ssm_parameter" "this" {
+  for_each = {
+    for parameter in var.parameters :
+    parameter.name => parameter
+  }
+
+  name        = join("", [var.path, each.key])
+  description = try(each.value.description, var.description)
+  tier        = local.tiers[try(each.value.tier, var.tier)]
+
+  type            = local.types[try(each.value.type, var.type)]
+  data_type       = try(each.value.data_type, var.data_type)
+  allowed_pattern = try(each.value.allowed_pattern, var.allowed_pattern)
+
+  insecure_value = each.value.value
+
+  # BUG: https://github.com/hashicorp/terraform-provider-aws/issues/25335
+  overwrite = true
+
+  tags = merge(
+    {
+      "Name" = join("", [var.path, each.key])
+    },
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/ssm-parameter-store-parameter-set/outputs.tf
+++ b/modules/ssm-parameter-store-parameter-set/outputs.tf
@@ -1,0 +1,25 @@
+output "path" {
+  description = "The path used for the prefix of each parameter names managed by this parameter set."
+  value       = var.path
+}
+
+output "parameters" {
+  description = "The list of parameters in the parameter set."
+  value = {
+    for name, parameter in aws_ssm_parameter.this :
+    name => {
+      id          = parameter.id
+      arn         = parameter.arn
+      name        = parameter.name
+      description = parameter.description
+      tier        = parameter.tier
+
+      type            = parameter.type
+      data_type       = parameter.data_type
+      allowed_pattern = parameter.allowed_pattern
+
+      value   = parameter.insecure_value
+      version = parameter.version
+    }
+  }
+}

--- a/modules/ssm-parameter-store-parameter-set/resource-group.tf
+++ b/modules/ssm-parameter-store-parameter-set/resource-group.tf
@@ -1,0 +1,44 @@
+locals {
+  resource_group_name = (var.resource_group_name != ""
+    ? var.resource_group_name
+    : join(".", [
+      local.metadata.package,
+      local.metadata.module,
+      replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+    ])
+  )
+  resource_group_filters = [
+    for key, value in local.module_tags : {
+      "Key"    = key
+      "Values" = [value]
+    }
+  ]
+  resource_group_query = <<-JSON
+  {
+    "ResourceTypeFilters": [
+      "AWS::AllSupported"
+    ],
+    "TagFilters": ${jsonencode(local.resource_group_filters)}
+  }
+  JSON
+}
+
+resource "aws_resourcegroups_group" "this" {
+  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+
+  name        = local.resource_group_name
+  description = var.resource_group_description
+
+  resource_query {
+    type  = "TAG_FILTERS_1_0"
+    query = local.resource_group_query
+  }
+
+  tags = merge(
+    {
+      "Name" = local.resource_group_name
+    },
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/ssm-parameter-store-parameter-set/variables.tf
+++ b/modules/ssm-parameter-store-parameter-set/variables.tf
@@ -1,0 +1,158 @@
+variable "path" {
+  description = "(Required) A path used for the prefix of each parameter name created by this parameter set. The path should begin with slash (/) and end without trailing slash."
+  type        = string
+
+  validation {
+    condition = alltrue([
+      substr(var.path, 0, 1) == "/",
+      substr(var.path, -1, 0) != "/",
+    ])
+    error_message = "The value of `path` should begin with slash (/) and end without trailing slash."
+  }
+}
+
+variable "description" {
+  description = "(Optional) The default description of parameters in the parameter set. This is only used when a specific description of the parameter is not provided."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}
+
+variable "tier" {
+  description = "(Optional) The default parameter tier to assign to parameters in the parameter set. This is only used when a specific tier of the parameter is not provided. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`. Defaults to `INTELLIGENT_TIERING`."
+  type        = string
+  default     = "INTELLIGENT_TIERING"
+  nullable    = false
+
+  validation {
+    condition     = contains(["STANDARD", "ADVANCED", "INTELLIGENT_TIERING"], var.tier)
+    error_message = "Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`."
+  }
+}
+
+variable "type" {
+  description = "(Optional) The default type of parameters in the parameter set. This is only used when a specific type of the parameter is not provided. Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`. Defaults to `STRING`."
+  type        = string
+  default     = "STRING"
+  nullable    = false
+
+  validation {
+    condition     = contains(["STRING", "STRING_LIST"], var.type)
+    error_message = "Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`."
+  }
+}
+
+variable "data_type" {
+  description = "(Optional) The default data type of parameters in the parameter set. Only required when `type` is `STRING`. This is only used when a specific data type of the parameter is not provided. Valid values are `text`, `aws:ec2:image` for AMI format. Defaults to `text`."
+  type        = string
+  default     = "text"
+  nullable    = false
+
+  validation {
+    condition     = contains(["text", "aws:ec2:image"], var.data_type)
+    error_message = "Valid values are `text`, `aws:ec2:image`."
+  }
+}
+
+variable "allowed_pattern" {
+  description = "(Optional) The default regular expression used to validate each parameter value in the parameter set. This is only used when a specific pattern for the parameter is not provided. For example, for `STRING` types with values restricted to numbers, you can specify `^d+$`."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "parameters" {
+  description = <<EOF
+  (Required) A list of parameters to manage in the parameter set. Each value of `parameters` block as defined below.
+    (Required) `name` - The name of the parameter. This is concatenated with the `path` of the parameter set for the id. The name should begin with slash (/) and end without trailing slash.
+    (Optional) `description` - The description of the parameter.
+    (Optional) `tier` - The parameter tier to assign to the parameter. Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`.
+    (Optional) `type` - The intended type of the parameter. Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`.
+    (Optional) `data_type` - The data type of the parameter. Only required when `type` is `STRING`. Valid values are `text`, `aws:ec2:image` for AMI format.
+    (Optional) `allowed_pattern` - A regular expression used to validate the parameter value.
+    (Required) `value` - The value of the parameter.
+  EOF
+  type        = list(map(string))
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      for parameter in var.parameters :
+      alltrue([
+        substr(parameter.name, 0, 1) == "/",
+        substr(parameter.name, -1, 0) != "/",
+      ])
+    ])
+    error_message = "The name should begin with slash (/) and end without trailing slash."
+  }
+
+  validation {
+    condition = alltrue([
+      for parameter in var.parameters :
+      contains(["STANDARD", "ADVANCED", "INTELLIGENT_TIERING"], parameter.tier)
+      if try(parameter.tier, null) != null
+    ])
+    error_message = "Valid values are `STANDARD`, `ADVANCED` or `INTELLIGENT_TIERING`."
+  }
+
+  validation {
+    condition = alltrue([
+      for parameter in var.parameters :
+      contains(["STRING", "STRING_LIST"], parameter.type)
+      if try(parameter.type, null) != null
+    ])
+    error_message = "Valid values are `STRING`, `STRING_LIST`. Not support `SECURE_STRING`."
+  }
+
+  validation {
+    condition = alltrue([
+      for parameter in var.parameters :
+      contains(["text", "aws:ec2:image"], parameter.data_type)
+      if try(parameter.data_type, null) != null
+    ])
+    error_message = "Valid values are `text`, `aws:ec2:image`."
+  }
+
+  validation {
+    condition = alltrue([
+      for parameter in var.parameters :
+      can(parameter.value)
+    ])
+    error_message = "The value for `value` is required."
+  }
+}
+
+variable "tags" {
+  description = "(Optional) A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "module_tags_enabled" {
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
+  type        = bool
+  default     = true
+}
+
+
+###################################################
+# Resource Group
+###################################################
+
+variable "resource_group_enabled" {
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
+  type        = bool
+  default     = true
+}
+
+variable "resource_group_name" {
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  type        = string
+  default     = ""
+}
+
+variable "resource_group_description" {
+  description = "(Optional) The description of Resource Group."
+  type        = string
+  default     = "Managed by Terraform."
+}

--- a/modules/ssm-parameter-store-parameter-set/versions.tf
+++ b/modules/ssm-parameter-store-parameter-set/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `ssm-parameter-store-parameter-set` module to manage a set of parameters within a same prefix path.