### PR TITLE
Support ignore_value_changes for ssm-parameter-store-parameter module

### DIFF
--- a/modules/kms-key/README.md
+++ b/modules/kms-key/README.md
@@ -11,14 +11,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
 
 ## Modules
 

--- a/modules/kms-key/variables.tf
+++ b/modules/kms-key/variables.tf
@@ -7,12 +7,14 @@ variable "description" {
   description = "(Optional) The description of the KMS key."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "usage" {
   description = "(Optional) Specifies the intended use of the key. Valid values are `ENCRYPT_DECRYPT` or `SIGN_VERIFY`."
   type        = string
   default     = "ENCRYPT_DECRYPT"
+  nullable    = false
 
   validation {
     condition     = contains(["ENCRYPT_DECRYPT", "SIGN_VERIFY"], var.usage)
@@ -24,6 +26,7 @@ variable "spec" {
   description = "(Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT`."
   type        = string
   default     = "SYMMETRIC_DEFAULT"
+  nullable    = false
 }
 
 variable "policy" {
@@ -36,12 +39,14 @@ variable "bypass_policy_lockout_safety_check" {
   description = "(Optional) Specifies whether to disable the policy lockout check performed when creating or updating the key's policy. Setting this value to true increases the risk that the CMK becomes unmanageable. For more information, refer to the scenario in the Default Key Policy section in the AWS Key Management Service Developer Guide."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deletion_window_in_days" {
   description = "(Optional) Duration in days after which the key is deleted after destruction of the resource. Valid value is between `7` and `30` days. Defaults to `30`."
   type        = number
   default     = 30
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -56,36 +61,42 @@ variable "enabled" {
   description = "(Optional) Indicates whether the key is enabled."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "key_rotation_enabled" {
   description = "(Optional) Indicates whether key rotation is enabled."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "multi_region_enabled" {
   description = "(Optional) Indicates whether the key is a multi-Region (true) or regional (false) key."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "aliases" {
   description = "(Optional) List of display name of the alias. The name must start with the word ``alias/`."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -97,16 +108,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/kms-key/versions.tf
+++ b/modules/kms-key/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.22"
     }
   }
 }

--- a/modules/secrets-manager-secret/README.md
+++ b/modules/secrets-manager-secret/README.md
@@ -12,14 +12,14 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
 
 ## Modules
 

--- a/modules/secrets-manager-secret/variables.tf
+++ b/modules/secrets-manager-secret/variables.tf
@@ -7,12 +7,14 @@ variable "description" {
   description = "(Optional) The description of the secret."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }
 
 variable "type" {
   description = "(Optional) The intended type of the secret. Valid values are `TEXT`, `KEY_VALUE` or `BINARY`."
   type        = string
   default     = "KEY_VALUE"
+  nullable    = false
 
   validation {
     condition     = contains(["TEXT", "KEY_VALUE", "BINARY"], var.type)
@@ -34,6 +36,7 @@ variable "versions" {
   EOF
   type        = any
   default     = []
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -73,12 +76,14 @@ variable "block_public_policy" {
   description = "(Optional) Whether to reject calls to PUT a resource policy if the policy allows public access."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deletion_window_in_days" {
   description = "(Optional) Duration in days after which the secret is deleted after destruction of the resource. Valid value is between `7` and `30` days. Defaults to `30`."
   type        = number
   default     = 30
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -97,12 +102,14 @@ variable "replicas" {
   EOF
   type        = list(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "overwrite_in_replicas" {
   description = "(Optional) Whether to overwrite a secret with the same name in the destination region during replication."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "rotation_lambda_function" {
@@ -121,12 +128,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -138,16 +147,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/secrets-manager-secret/versions.tf
+++ b/modules/secrets-manager-secret/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.22"
     }
   }
 }

--- a/modules/ssm-parameter-store-parameter-set/README.md
+++ b/modules/ssm-parameter-store-parameter-set/README.md
@@ -27,6 +27,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_ssm_parameter.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 
 ## Inputs
@@ -38,6 +39,7 @@ No modules.
 | <a name="input_allowed_pattern"></a> [allowed\_pattern](#input\_allowed\_pattern) | (Optional) The default regular expression used to validate each parameter value in the parameter set. This is only used when a specific pattern for the parameter is not provided. For example, for `STRING` types with values restricted to numbers, you can specify `^d+$`. | `string` | `""` | no |
 | <a name="input_data_type"></a> [data\_type](#input\_data\_type) | (Optional) The default data type of parameters in the parameter set. Only required when `type` is `STRING`. This is only used when a specific data type of the parameter is not provided. Valid values are `text`, `aws:ec2:image` for AMI format. Defaults to `text`. | `string` | `"text"` | no |
 | <a name="input_description"></a> [description](#input\_description) | (Optional) The default description of parameters in the parameter set. This is only used when a specific description of the parameter is not provided. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | (Optional) Whether to manage the parameter value with Terraform. Ignore changes of `value` or `secret_value` if true. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |

--- a/modules/ssm-parameter-store-parameter-set/main.tf
+++ b/modules/ssm-parameter-store-parameter-set/main.tf
@@ -36,6 +36,7 @@ resource "aws_ssm_parameter" "this" {
   for_each = {
     for parameter in var.parameters :
     parameter.name => parameter
+    if !var.ignore_value_changes
   }
 
   name        = join("", [var.path, each.key])
@@ -58,4 +59,40 @@ resource "aws_ssm_parameter" "this" {
     local.module_tags,
     var.tags,
   )
+}
+
+resource "aws_ssm_parameter" "self" {
+  for_each = {
+    for parameter in var.parameters :
+    parameter.name => parameter
+    if var.ignore_value_changes
+  }
+
+  name        = join("", [var.path, each.key])
+  description = try(each.value.description, var.description)
+  tier        = local.tiers[try(each.value.tier, var.tier)]
+
+  type            = local.types[try(each.value.type, var.type)]
+  data_type       = try(each.value.data_type, var.data_type)
+  allowed_pattern = try(each.value.allowed_pattern, var.allowed_pattern)
+
+  insecure_value = each.value.value
+
+  # BUG: https://github.com/hashicorp/terraform-provider-aws/issues/25335
+  overwrite = true
+
+  tags = merge(
+    {
+      "Name" = join("", [var.path, each.key])
+    },
+    local.module_tags,
+    var.tags,
+  )
+
+  lifecycle {
+    ignore_changes = [
+      value,
+      insecure_value,
+    ]
+  }
 }

--- a/modules/ssm-parameter-store-parameter-set/outputs.tf
+++ b/modules/ssm-parameter-store-parameter-set/outputs.tf
@@ -1,3 +1,7 @@
+locals {
+  parameter_set = var.ignore_value_changes ? aws_ssm_parameter.self : aws_ssm_parameter.this
+}
+
 output "path" {
   description = "The path used for the prefix of each parameter names managed by this parameter set."
   value       = var.path
@@ -6,7 +10,7 @@ output "path" {
 output "parameters" {
   description = "The list of parameters in the parameter set."
   value = {
-    for name, parameter in aws_ssm_parameter.this :
+    for name, parameter in local.parameter_set :
     name => {
       id          = parameter.id
       arn         = parameter.arn

--- a/modules/ssm-parameter-store-parameter-set/variables.tf
+++ b/modules/ssm-parameter-store-parameter-set/variables.tf
@@ -122,16 +122,25 @@ variable "parameters" {
   }
 }
 
+variable "ignore_value_changes" {
+  description = "(Optional) Whether to manage the parameter value with Terraform. Ignore changes of `value` or `secret_value` if true. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -143,16 +152,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/ssm-parameter-store-parameter/README.md
+++ b/modules/ssm-parameter-store-parameter/README.md
@@ -27,6 +27,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_ssm_parameter.self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 
 ## Inputs
@@ -37,6 +38,7 @@ No modules.
 | <a name="input_allowed_pattern"></a> [allowed\_pattern](#input\_allowed\_pattern) | (Optional) A regular expression used to validate the parameter value. For example, for `STRING` types with values restricted to numbers, you can specify `^d+$`. | `string` | `""` | no |
 | <a name="input_data_type"></a> [data\_type](#input\_data\_type) | (Optional) The data type of the parameter. Only required when `type` is `STRING`. Valid values are `text`, `aws:ec2:image` for AMI format. Defaults to `text`. | `string` | `"text"` | no |
 | <a name="input_description"></a> [description](#input\_description) | (Optional) The description of the parameter. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | (Optional) Whether to manage the parameter value with Terraform. Ignore changes of `value` or `secret_value` if true. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | (Optional) The ARN or ID of the AWS KMS key to be used to encrypt the parameter value with `SECURE_STRING` type. If you don't specify this value, then Parameter Store defaults to using the AWS account's default KMS key named `aws/ssm`. If the default KMS key with that name doesn't yet exist, then AWS Parameter Store creates it for you automatically the first time. | `string` | `null` | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
@@ -59,9 +61,9 @@ No modules.
 | <a name="output_id"></a> [id](#output\_id) | The ID of the parameter. |
 | <a name="output_kms_key"></a> [kms\_key](#output\_kms\_key) | The ARN or ID of the AWS KMS key which is used to encrypt the parameter value. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the parameter. |
-| <a name="output_secret_value"></a> [secret\_value](#output\_secret\_value) | The secure value of the parameter. This argument is valid with a type of `SECURE_STRING`. |
+| <a name="output_secret_value"></a> [secret\_value](#output\_secret\_value) | The secure value of the parameter. argument is valid with a type of `SECURE_STRING`. |
 | <a name="output_tier"></a> [tier](#output\_tier) | The tier of the parameter. |
 | <a name="output_type"></a> [type](#output\_type) | The type of the parameter. |
-| <a name="output_value"></a> [value](#output\_value) | The value of the parameter. This argument is not valid with a type of `SECURE_STRING`. |
+| <a name="output_value"></a> [value](#output\_value) | The value of the parameter. argument is not valid with a type of `SECURE_STRING`. |
 | <a name="output_version"></a> [version](#output\_version) | The current version of the parameter. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssm-parameter-store-parameter/outputs.tf
+++ b/modules/ssm-parameter-store-parameter/outputs.tf
@@ -1,21 +1,25 @@
+locals {
+  parameter = try(aws_ssm_parameter.this[0], aws_ssm_parameter.self[0])
+}
+
 output "arn" {
   description = "The ARN of the parameter."
-  value       = aws_ssm_parameter.this.arn
+  value       = local.parameter.arn
 }
 
 output "id" {
   description = "The ID of the parameter."
-  value       = aws_ssm_parameter.this.id
+  value       = local.parameter.id
 }
 
 output "name" {
   description = "The name of the parameter."
-  value       = aws_ssm_parameter.this.name
+  value       = local.parameter.name
 }
 
 output "description" {
   description = "The description of the parameter."
-  value       = aws_ssm_parameter.this.description
+  value       = local.parameter.description
 }
 
 output "tier" {
@@ -23,7 +27,7 @@ output "tier" {
   value = {
     for k, v in local.tiers :
     v => k
-  }[aws_ssm_parameter.this.tier]
+  }[local.parameter.tier]
 }
 
 output "type" {
@@ -31,36 +35,36 @@ output "type" {
   value = {
     for k, v in local.types :
     v => k
-  }[aws_ssm_parameter.this.type]
+  }[local.parameter.type]
 }
 
 output "data_type" {
   description = "The data type of the parameter. Only required when `type` is `STRING`."
-  value       = aws_ssm_parameter.this.data_type
+  value       = local.parameter.data_type
 }
 
 output "allowed_pattern" {
   description = "The regular expression used to validate the parameter value."
-  value       = aws_ssm_parameter.this.allowed_pattern
+  value       = local.parameter.allowed_pattern
 }
 
 output "value" {
-  description = "The value of the parameter. This argument is not valid with a type of `SECURE_STRING`."
-  value       = aws_ssm_parameter.this.insecure_value
+  description = "The value of the parameter. argument is not valid with a type of `SECURE_STRING`."
+  value       = local.parameter.insecure_value
 }
 
 output "secret_value" {
-  description = "The secure value of the parameter. This argument is valid with a type of `SECURE_STRING`."
-  value       = aws_ssm_parameter.this.value
+  description = "The secure value of the parameter. argument is valid with a type of `SECURE_STRING`."
+  value       = local.parameter.value
   sensitive   = true
 }
 
 output "kms_key" {
   description = "The ARN or ID of the AWS KMS key which is used to encrypt the parameter value."
-  value       = aws_ssm_parameter.this.key_id
+  value       = local.parameter.key_id
 }
 
 output "version" {
   description = "The current version of the parameter."
-  value       = aws_ssm_parameter.this.version
+  value       = local.parameter.version
 }

--- a/modules/ssm-parameter-store-parameter/variables.tf
+++ b/modules/ssm-parameter-store-parameter/variables.tf
@@ -76,16 +76,25 @@ variable "kms_key" {
   default     = null
 }
 
+variable "ignore_value_changes" {
+  description = "(Optional) Whether to manage the parameter value with Terraform. Ignore changes of `value` or `secret_value` if true. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -97,16 +106,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }


### PR DESCRIPTION
### Background

- Support `ignore_value_changes` argument for parameters on Parameter Store. It enables to manage parameter values in the outside of Terraform.